### PR TITLE
fixes hardcoded DA namespaces

### DIFF
--- a/src/app/props-provider/CustomPropsProvider.ts
+++ b/src/app/props-provider/CustomPropsProvider.ts
@@ -26,6 +26,7 @@ export class CustomPropsProvider implements IPropertiesProvider {
   static types = [{ name: 'none', value: 'none' }, { name: 'VALUE', value: 'VALUE' }, { name: 'String', value: 'String' }, { name: 'DA', value: 'DA' }];
   static DA = [{ name: 'none', value: 'none' }];
   static moddle = new BpmnModdle({ camunda: _camundaModdleDescriptor });
+  // name contains the namespace of the da, value contains the fileName
   static references = [{ name: 'none', value: 'none' }];
   static properties = [];
   static int = [];
@@ -59,7 +60,7 @@ export class CustomPropsProvider implements IPropertiesProvider {
         }
       }
     }
-    console.log('inerfaceloadfuinction');
+    console.log('inerfaceloadfunction');
     console.log(CustomPropsProvider.int);
   }
 
@@ -549,13 +550,14 @@ export class CustomPropsProvider implements IPropertiesProvider {
                       let da = values['qa:deploymentArtifact'];
                       if (reference.includes(da)) {
                         namespaceDA = reference;
+                        fileName = CustomPropsProvider.references[d].value;
                       }
                     }
                     for (let o = 0; o < element.businessObject.extensionElements.values[0].inputParameters.length; o++) {
                       let extensionElement = element.businessObject.extensionElements.values[0].inputParameters[o].name;
                       extensionElement = extensionElement.split('Input_')[1];
                       if (name === extensionElement) {
-                        element.businessObject.extensionElements.values[0].inputParameters[o].value = 'DA!' + '{' + namespaceDA + '}' + values['qa:deploymentArtifact'] + '#' + fileName;
+                        element.businessObject.extensionElements.values[0].inputParameters[o].value = 'DA!' + namespaceDA + '#' + fileName;
                       }
                     }
                     return;

--- a/src/app/props-provider/CustomPropsProvider.ts
+++ b/src/app/props-provider/CustomPropsProvider.ts
@@ -555,7 +555,7 @@ export class CustomPropsProvider implements IPropertiesProvider {
                       let extensionElement = element.businessObject.extensionElements.values[0].inputParameters[o].name;
                       extensionElement = extensionElement.split('Input_')[1];
                       if (name === extensionElement) {
-                        element.businessObject.extensionElements.values[0].inputParameters[o].value = 'DA!' + namespaceDA + values['qa:deploymentArtifact'] + '#' + fileName;
+                        element.businessObject.extensionElements.values[0].inputParameters[o].value = 'DA!' + '{' + namespaceDA + '}' + values['qa:deploymentArtifact'] + '#' + fileName;
                       }
                     }
                     return;

--- a/src/app/props-provider/CustomPropsProvider.ts
+++ b/src/app/props-provider/CustomPropsProvider.ts
@@ -23,13 +23,10 @@ export class CustomPropsProvider implements IPropertiesProvider {
   static relationshiptemplate = [{ name: 'none', value: 'none' }];
   static winery2: WineryService;
   static tosca = [];
-  static opt = [{ name: 'INITIAL', value: 'INITIAL' }, { name: 'CREATING', value: 'CREATING' }, { name: 'CREATED', value: 'CREATED' }, { name: 'CONFIGURING', value: 'CONFIGURING' },
-  { name: 'STARTING', value: 'STARTING' }, { name: 'STARTED', value: 'STARTED' }, { name: 'STOPPING', value: 'STOPPING' }, { name: 'STOPPED', value: 'STOPPED' }, { name: 'DELETING', value: 'DELETING' },
-  { name: 'DELETED', value: 'DELETED' }, { name: 'ERROR', value: 'ERROR' }, { name: 'MIGRATED', value: 'MIGRATED' }];
   static types = [{ name: 'none', value: 'none' }, { name: 'VALUE', value: 'VALUE' }, { name: 'String', value: 'String' }, { name: 'DA', value: 'DA' }];
   static DA = [{ name: 'none', value: 'none' }];
   static moddle = new BpmnModdle({ camunda: _camundaModdleDescriptor });
-  static references = [];
+  static references = [{ name: 'none', value: 'none' }];
   static properties = [];
   static int = [];
   static nodetemplateindex = -1;
@@ -346,15 +343,17 @@ export class CustomPropsProvider implements IPropertiesProvider {
                     if (element.businessObject.$attrs['qa:interface'] !== undefined) {
                       if ((CustomPropsProvider.int.length > 0) && (CustomPropsProvider.operations.length === 0) && (CustomPropsProvider.nodetemplateindex !== -1)) {
                         for (let i = 0; i < CustomPropsProvider.interfaces.length; i++) {
-                          if (element.businessObject.$attrs['qa:interface'] === CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].name) {
-                            if (CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value != undefined) {
+                          if (CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i] !== undefined) {
+                            if (element.businessObject.$attrs['qa:interface'] === CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].name) {
+                              if (CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value != undefined) {
 
-                              for (let j = 0; j < CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value.length; j++) {
-                                CustomPropsProvider.operations.push({
-                                  name: CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value[j].name,
-                                  value: CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value[j].name
-                                });
-                                CustomPropsProvider.interfaceindex = i;
+                                for (let j = 0; j < CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value.length; j++) {
+                                  CustomPropsProvider.operations.push({
+                                    name: CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value[j].name,
+                                    value: CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[i].value[j].name
+                                  });
+                                  CustomPropsProvider.interfaceindex = i;
+                                }
                               }
                             }
                           }
@@ -388,7 +387,7 @@ export class CustomPropsProvider implements IPropertiesProvider {
                                 CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[CustomPropsProvider.interfaceindex].value[k].name)
                                 && (CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].interfaces[CustomPropsProvider.interfaceindex].value[k].
                                   hasOwnProperty('inputParameters'))) {
-                                    
+
                                 for (let l = 0; l < CustomPropsProvider.int[CustomPropsProvider.nodetemplateindex].
                                   interfaces[CustomPropsProvider.interfaceindex].value[k].inputParameters.length; l++) {
                                   // warum so und dann splitten??
@@ -543,19 +542,20 @@ export class CustomPropsProvider implements IPropertiesProvider {
                     let name = element.businessObject.$attrs['qa:inputParams'].split(",")[0];
                     let reference = '';
                     let fileName = '';
-                    for (let d = 0; d < CustomPropsProvider.references.length; d++) {
-                      reference = CustomPropsProvider.references[d];
+                    let namespaceDA = '';
+                    //element.businessObject.$attrs['qa:namespaceDA'];
+                    for (let d = 1; d < CustomPropsProvider.references.length; d++) {
+                      reference = CustomPropsProvider.references[d].name;
                       let da = values['qa:deploymentArtifact'];
                       if (reference.includes(da)) {
-                        let index = reference.lastIndexOf('/');
-                        fileName = reference.substring(index + 1);
+                        namespaceDA = reference;
                       }
                     }
                     for (let o = 0; o < element.businessObject.extensionElements.values[0].inputParameters.length; o++) {
                       let extensionElement = element.businessObject.extensionElements.values[0].inputParameters[o].name;
                       extensionElement = extensionElement.split('Input_')[1];
                       if (name === extensionElement) {
-                        element.businessObject.extensionElements.values[0].inputParameters[o].value = 'DA!' + values['qa:deploymentArtifact'] + '#' + fileName;
+                        element.businessObject.extensionElements.values[0].inputParameters[o].value = 'DA!' + namespaceDA + values['qa:deploymentArtifact'] + '#' + fileName;
                       }
                     }
                     return;
@@ -900,13 +900,13 @@ export class CustomPropsProvider implements IPropertiesProvider {
                   //description: 'State',
                   label: 'State',
                   selectOptions: function (element, values) {
-                    let opt = [{ name: '', value: '' }, { name: 'INITIAL', value: 'INITIAL' }, { name: 'CREATING', value: 'CREATING' }, { name: 'CREATED', value: 'CREATED' }, { name: 'CONFIGURING', value: 'CONFIGURING' },
+                    let states = [{ name: '', value: '' }, { name: 'INITIAL', value: 'INITIAL' }, { name: 'CREATING', value: 'CREATING' }, { name: 'CREATED', value: 'CREATED' }, { name: 'CONFIGURING', value: 'CONFIGURING' },
                     { name: 'STARTING', value: 'STARTING' }, { name: 'STARTED', value: 'STARTED' }, { name: 'STOPPING', value: 'STOPPING' }, { name: 'STOPPED', value: 'STOPPED' }, { name: 'DELETING', value: 'DELETING' },
                     { name: 'DELETED', value: 'DELETED' }, { name: 'ERROR', value: 'ERROR' }, { name: 'MIGRATED', value: 'MIGRATED' }];
                     if (values.selectedOptions.length > 0 && (values.selectedOptions[0] != undefined)) {
                       element.businessObject.extensionElements.values[0].inputParameters[0].value = values.selectedOptions[0].value;
                     }
-                    return opt;
+                    return states;
 
                   },
                   setControlValue: true,

--- a/src/app/services/winery.service.ts
+++ b/src/app/services/winery.service.ts
@@ -55,25 +55,24 @@ export class WineryService {
             //this.loadPlan();
         }
     }
-    public getArtifactTemplates(ref: string) {
-        console.info(ref);
-        console.info("Compute deployment artifacts")
-        //http://localhost:8080/winery/artifacttemplates/http%253A%252F%252Fopentosca.org%252Fartifacttemplates/MyTinyToDo_DA/xml
+    public getFileNameOfArtifactTemplates(ref: string) {
+        console.info("Compute file name of deployment artifacts")
         let httpserv = this.http;
         let namespace = ref.split('}')[0];
         namespace = namespace.replace('{', '');
         let da = ref.split('}')[1];
         const url = 'artifacttemplates/' + this.encode(namespace) + '/' + da + '/xml';
         const headers = new HttpHeaders({ 'Content-Type': 'application/xml' });
-        console.log(this.getFullUrl(url))
         httpserv.get(this.getFullUrl(url), {
             headers: headers, responseType: 'text'
         }).subscribe(response => {
             let parser = new DOMParser();
-            console.info("Add corresponding reference of da");
             let reference = parser.parseFromString(response, "text/xml").getElementsByTagName("ArtifactReference")[0].getAttribute("reference");
-            console.info(reference);
-           // CustomPropsProvider.references.push(reference);
+            let fileNameIndex = reference.lastIndexOf('/');
+            let fileName = reference.substring(fileNameIndex + 1);
+            CustomPropsProvider.references.push({
+                name: ref, value: fileName
+            })
         })
 
     }
@@ -125,20 +124,17 @@ export class WineryService {
                     }
                     if (nodeTemplate.deploymentArtifacts !== undefined) {
                         console.log(nodeTemplate.deploymentArtifacts);
-                            for (var k = 0; k < nodeTemplate.deploymentArtifacts.length; k++) {
-                                let ref = nodeTemplate.deploymentArtifacts[k].artifactRef;
-                                //this.getArtifactTemplates(ref);
-                                let index = ref.indexOf("}");
-                                let daName = ref.substring(index + 1);
-                                CustomPropsProvider.references.push({
-                                    name: ref, value:ref
-                                })
-                                CustomPropsProvider.DA.push({
-                                    value: daName, name:
-                                        daName
-                                });
-                            }
+                        for (var k = 0; k < nodeTemplate.deploymentArtifacts.length; k++) {
+                            let ref = nodeTemplate.deploymentArtifacts[k].artifactRef;
+                            this.getFileNameOfArtifactTemplates(ref);
+                            let index = ref.indexOf("}");
+                            let daName = ref.substring(index + 1);
+                            CustomPropsProvider.DA.push({
+                                value: daName, name:
+                                    daName
+                            });
                         }
+                    }
                 }
                 if (!containsParam) {
                     CustomPropsProvider.template.push({
@@ -146,8 +142,8 @@ export class WineryService {
                             nodeTemplate.id
                     });
                     CustomPropsProvider.properties.push(nodeTemplate);
-                    
-                
+
+
                 }
                 if (CustomPropsProvider.template.length == 0) {
                     CustomPropsProvider.template.push({
@@ -158,13 +154,12 @@ export class WineryService {
                     if (nodeTemplate.deploymentArtifacts != undefined) {
                         for (var k = 0; k < nodeTemplate.deploymentArtifacts.length; k++) {
                             let ref = nodeTemplate.deploymentArtifacts[k].artifactRef;
-                            //this.getArtifactTemplates(ref);
-                            CustomPropsProvider.references.push({
-                                name: ref, value:ref
-                            })
+                            this.getFileNameOfArtifactTemplates(ref);
+                            let index = ref.indexOf("}");
+                            let daName = ref.substring(index + 1);
                             CustomPropsProvider.DA.push({
-                                value: nodeTemplate.deploymentArtifacts[k].artifactRef, name:
-                                    nodeTemplate.deploymentArtifacts[k].artifactRef
+                                value: daName, name:
+                                    daName
                             });
                         }
                     }

--- a/src/assets/CallNodeOperation.groovy
+++ b/src/assets/CallNodeOperation.groovy
@@ -26,9 +26,10 @@ for(int i in 0..inputParamNames.size()-1){
            def paramDA = execution.getVariable("instanceDataAPIUrl").split("/servicetemplates")[0];
            def da = param.split("#")[0];
            def fileName = param.split("#")[1];
-           def namespace = URLEncoder.encode('http://opentosca.org/artifacttemplates', "UTF-8");
+           def namespace = URLEncoder.encode(da.split("}")[0].substring(1), "UTF-8");
+		   def daName = da.split("}")[1]
            namespace = URLEncoder.encode(namespace, "UTF-8");
-           paramDA= paramDA+'/content/artifacttemplates/'+namespace+'/'+ da + '/files/' + fileName;
+           paramDA= paramDA+'/content/artifacttemplates/'+namespace+'/'+ daName + '/files/' + fileName;
            param = paramDA;
         }
         if(type=='VALUE'){


### PR DESCRIPTION
Currently the namespace is hardcoded in CallNodeOperation.groovy

I have a fix for the script however I'm not sure what has to be done to enable it properly in the UI, e.g., this would be a proper snippet the groocy script could work with:
```xml

					<camunda:inputParameter name="Input_ContainerMountPath"/>
					<camunda:inputParameter name="Input_VMIP"/>
					<camunda:inputParameter name="Input_VMPrivateKey"/>
					<camunda:inputParameter name="Input_ImageLocation">DA!{http://opentosca.org/example/applications/artifacttemplates}MyTinyToDo_DA-w1#tinytodo.zip</camunda:inputParameter>
					<camunda:outputParameter name="Output_ContainerPorts"/>
		
```

Note the ImageLocation param with 

> DA!{http://opentosca.org/example/applications/artifacttemplates}MyTinyToDo_DA-w1#tinytodo.zip

Previously, or better, right now there is no namespace given, only the name when added in the modeller:
> DA!MyTinyToDo_DA-w1#tinytodo.zip

Therefore the namespace was hardcoded.
Can we fix this ?